### PR TITLE
fixL sttRoute

### DIFF
--- a/routes/ai/sttRoutes.js
+++ b/routes/ai/sttRoutes.js
@@ -1,51 +1,74 @@
-const express = require('express');
+// routes/stt.js
+const express = require("express");
 const router = express.Router();
-const multer = require('multer');
-const axios = require('axios');
-const FormData = require('form-data');
+const multer = require("multer");
+const axios = require("axios");
+const FormData = require("form-data");
 const upload = multer({ storage: multer.memoryStorage() });
 
-// STT 음성-텍스트 변환 라우트
-router.post('/', upload.single('file'), async (req, res) => {
-    try {
-        // 파일 체크
-        if (!req.file) {
-            return res.status(400).json({ error: '음성 파일이 필요합니다.' });
-        }
+const STT_API_URL = "http://localhost:8002";
 
-        // FormData 생성
-        const formData = new FormData();
-        formData.append('audio_file', req.file.buffer, {
-            filename: req.file.originalname,
-            contentType: req.file.mimetype
-        });
+router.post("/", upload.single("audio_file"), async (req, res) => {
+  try {
+    console.log("STT 라우트 호출됨");
+    console.log("받은 파일 정보:", {
+      fieldname: req.file?.fieldname,
+      originalname: req.file?.originalname,
+      mimetype: req.file?.mimetype,
+      size: req.file?.size,
+    });
 
-        // Python FastAPI 서버로 요청
-        const response = await axios.post('http://localhost:8000/transcribe', formData, {
-            headers: {
-                ...formData.getHeaders(),
-            },
-            maxContentLength: Infinity,
-            maxBodyLength: Infinity
-        });
-
-        // 결과 반환
-        res.json(response.data);
-
-    } catch (error) {
-        console.error('STT 처리 중 오류:', error);
-        
-        // 에러 응답 처리
-        const errorMessage = error.response?.data?.error || error.message || '음성 처리 중 오류가 발생했습니다.';
-        res.status(error.response?.status || 500).json({
-            error: errorMessage
-        });
+    // 파일 체크
+    if (!req.file) {
+      console.log("파일이 없음");
+      return res.status(400).json({ error: "음성 파일이 필요합니다." });
     }
-});
 
-// STT 상태 확인 라우트
-router.get('/health', (req, res) => {
-    res.json({ status: 'ok', service: 'STT Service' });
+    // FormData 생성
+    const formData = new FormData();
+    formData.append("audio_file", req.file.buffer, {
+      filename: req.file.originalname,
+      contentType: req.file.mimetype,
+    });
+
+    console.log(
+      "STT 서버로 요청 보내기:",
+      `${STT_API_URL}/api/ai/stt/transcribe`
+    );
+
+    // Python FastAPI STT 서버로 요청
+    const response = await axios.post(
+      `${STT_API_URL}/api/ai/stt/transcribe`,
+      formData,
+      {
+        headers: {
+          ...formData.getHeaders(),
+        },
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+      }
+    );
+
+    console.log("STT 서버 응답:", response.data);
+
+    // 결과 반환
+    res.json(response.data);
+  } catch (error) {
+    console.error("STT 처리 중 오류:", {
+      message: error.message,
+      status: error.response?.status,
+      data: error.response?.data,
+      config: error.config,
+    });
+
+    const errorMessage =
+      error.response?.data?.error ||
+      error.message ||
+      "음성 처리 중 오류가 발생했습니다.";
+    res.status(error.response?.status || 500).json({
+      error: errorMessage,
+    });
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
URL 엔드포인트 변경:
이전: http://localhost:8000/transcribe
현재: http://localhost:8002/api/ai/stt/transcribe

파일 필드명 변경:
이전: upload.single('file')
현재: upload.single('audio_file')

로깅 추가:
STT 라우트 호출 로그
받은 파일 정보 로그
STT 서버로 요청 보내는 URL 로그
STT 서버 응답 로그
에러 로깅이 더 자세해짐

/health 엔드포인트 제거:
이전 코드에 있던 상태 확인 라우트가 제거됨

에러 처리 개선:
에러 로깅이 더 자세해짐
에러 객체의 status, data, config 정보까지 로깅